### PR TITLE
check for un-auth stream while discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.3.2
+## 1.4.0
   * Exclude 403-forbidden streams from discovery [#36](https://github.com/singer-io/tap-listrak/pull/36)
   * Bump dependencies for compliance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.2
+  * Exclude 403-forbidden streams from discovery [#36](https://github.com/singer-io/tap-listrak/pull/36)
+  * Bump dependencies for compliance
+
 ## 1.3.1
   * Fix for timezone aware comparisons. [#32](https://github.com/singer-io/tap-listrak/pull/32)
   * Fixes `sync_messages` to handle `WSMessageActivity` being `None` or an empty list inside a truthy `ReportListMessageActivityResult`, preventing `TypeError` and `ValueError` crashes.

--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,18 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-listrak",
-    version="1.3.1",
+    version="1.4.0",
     description="Singer.io tap for extracting data from the Listrak API",
     author="Stitch",
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["tap_listrak"],
     install_requires=[
-        "singer-python==6.7.0",
-        "requests==2.33.0",
+        "singer-python==6.8.0",
+        "requests==2.34.2",
         "zeep==4.3.2",
         'backoff==2.2.1',
-        'pendulum==3.1.0'
+        'pendulum==3.2.0'
     ],
     entry_points="""
     [console_scripts]

--- a/tap_listrak/__init__.py
+++ b/tap_listrak/__init__.py
@@ -45,7 +45,13 @@ def check_credentials_are_authorized(ctx):
         response = ctx.client.service.GetContactListCollection()
         LOGGER.info("Stream 'lists' is accessible.")
         lists = response or []
-        return lists[0].ListID if lists else None
+        if not lists:
+            raise ListrakForbiddenError(
+                "HTTP-error-code: 403, Error: The account credentials supplied do not have "
+                "'read' access to any of the streams supported by the tap. "
+                "Data collection cannot be initiated: No lists found in the account."
+            )
+        return lists[0].ListID
     except Fault as e:
         raise ListrakForbiddenError(
             "HTTP-error-code: 403, Error: The account credentials supplied do not have "
@@ -142,39 +148,32 @@ def discover(ctx):
     inaccessible = set()
     accessible_stream_ids = set(schemas.stream_ids)
 
-    # Step 1: probe 'lists' — raises immediately if inaccessible.
+    # Step 1: probe 'lists' — raises immediately if inaccessible or empty.
     list_id = check_credentials_are_authorized(ctx)
 
-    if list_id is not None:
-        # Step 2: probe 'messages' and 'subscribed_contacts' with the ListID.
-        messages_accessible, msg_id = _probe_list_dependent(ctx, 'messages', list_id)
-        if not messages_accessible:
-            accessible_stream_ids.discard('messages')
-            inaccessible.add('messages')
+    # Step 2: probe 'messages' and 'subscribed_contacts' with the ListID.
+    messages_accessible, msg_id = _probe_list_dependent(ctx, 'messages', list_id)
+    if not messages_accessible:
+        accessible_stream_ids.discard('messages')
+        inaccessible.add('messages')
+        _prune_inaccessible_children(accessible_stream_ids, inaccessible)
 
-        sc_accessible, _ = _probe_list_dependent(ctx, 'subscribed_contacts', list_id)
-        if not sc_accessible:
-            accessible_stream_ids.discard('subscribed_contacts')
-            inaccessible.add('subscribed_contacts')
+    sc_accessible, _ = _probe_list_dependent(ctx, 'subscribed_contacts', list_id)
+    if not sc_accessible:
+        accessible_stream_ids.discard('subscribed_contacts')
+        inaccessible.add('subscribed_contacts')
 
-        # Step 3: probe message_* sub-streams with the MsgID.
-        if messages_accessible and msg_id is not None:
-            for stream_id in _MESSAGE_SUBSTREAM_ENDPOINTS:
-                if not _probe_message_substream(ctx, stream_id, msg_id):
-                    accessible_stream_ids.discard(stream_id)
-                    inaccessible.add(stream_id)
-        elif messages_accessible:
-            LOGGER.warning(
-                "No messages found in account history; skipping access check for "
-                "message_* sub-streams — they will be included in the catalog."
-            )
-    else:
+    # Step 3: probe message_* sub-streams with the MsgID.
+    if messages_accessible and msg_id is not None:
+        for stream_id in _MESSAGE_SUBSTREAM_ENDPOINTS:
+            if not _probe_message_substream(ctx, stream_id, msg_id):
+                accessible_stream_ids.discard(stream_id)
+                inaccessible.add(stream_id)
+    elif messages_accessible:
         LOGGER.warning(
-            "No lists found in the account; skipping access check for child streams."
+            "No messages found in account history; skipping access check for "
+            "message_* sub-streams — they will be included in the catalog."
         )
-
-    # Cascade: remove message_* children if messages was excluded.
-    _prune_inaccessible_children(accessible_stream_ids, inaccessible)
 
     if inaccessible:
         LOGGER.warning(

--- a/tap_listrak/__init__.py
+++ b/tap_listrak/__init__.py
@@ -47,16 +47,14 @@ def check_credentials_are_authorized(ctx):
         lists = response or []
         if not lists:
             raise ListrakForbiddenError(
-                "HTTP-error-code: 403, Error: The account credentials supplied do not have "
-                "'read' access to any of the streams supported by the tap. "
-                "Data collection cannot be initiated: No lists found in the account."
+                "HTTP-error-code: 403, Error: Credentials are valid but "
+                "no lists were found in the account."
             )
         return lists[0].ListID
     except Fault as e:
         raise ListrakForbiddenError(
-            "HTTP-error-code: 403, Error: The account credentials supplied do not have "
-            "'read' access to any of the streams supported by the tap. "
-            "Data collection cannot be initiated: {}".format(e)
+            "HTTP-error-code: 403, Error: The credentials do not have "
+            "'read' access to any supported streams: %s" % e
         ) from e
 
 
@@ -171,14 +169,13 @@ def discover(ctx):
                 inaccessible.add(stream_id)
     elif messages_accessible:
         LOGGER.warning(
-            "No messages found in account history; skipping access check for "
-            "message_* sub-streams — they will be included in the catalog."
+            "No messages found in account history; message_* sub-streams "
+            "included in catalog without access check."
         )
 
     if inaccessible:
         LOGGER.warning(
-            "The account credentials supplied do not have 'read' access to the "
-            "following stream(s): %s. These streams have been excluded from the catalog.",
+            "No 'read' access to stream(s): %s. Excluded from catalog.",
             ", ".join(sorted(inaccessible)),
         )
 

--- a/tap_listrak/__init__.py
+++ b/tap_listrak/__init__.py
@@ -2,13 +2,17 @@
 import singer
 from singer import utils, metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
+from zeep.exceptions import Fault
 from . import streams as streams_
 from .context import Context
 from . import schemas
+from .http import ListrakForbiddenError
 
 REQUIRED_CONFIG_KEYS = ["start_date", "username", "password"]
 LOGGER = singer.get_logger()
 
+# Maps each child stream to its direct parent stream.
+# Used to cascade-remove children when a parent stream is inaccessible.
 STREAM_DEPENDENCIES = {
     'messages': 'lists',
     'message_bounces': 'messages',
@@ -20,16 +24,96 @@ STREAM_DEPENDENCIES = {
     'subscribed_contacts': 'lists'
 }
 
+# Only 'lists' can be probed during discovery without needing data IDs from
+# a prior API call. Child streams (messages, message_*, subscribed_contacts)
+# all require ListID or MsgID obtained at sync time.
+_PROBEABLE_STREAMS = {
+    'lists': 'GetContactListCollection',
+}
+
 
 def check_credentials_are_authorized(ctx):
-    pass
+    """
+    Probe the 'lists' stream via GetContactListCollection to verify the
+    account credentials have read access to the Listrak SOAP API.
+
+    A zeep.Fault exception indicates the credentials lack sufficient access.
+    Raises ListrakForbiddenError if the probe fails.
+
+    Since 'lists' is the root dependency for all streams, a failed probe
+    means no data can be collected.
+    """
+    try:
+        ctx.client.service.GetContactListCollection()
+        LOGGER.info("Listrak credentials verified: 'lists' stream is accessible.")
+    except Fault as e:
+        raise ListrakForbiddenError(
+            "Error: The account credentials supplied do not have 'read' access "
+            "to the Listrak API. Data collection cannot be initiated: {}".format(e)
+        ) from e
+
+
+def _prune_inaccessible_children(stream_ids, inaccessible):
+    """
+    Remove child streams from stream_ids whose parent stream is inaccessible.
+    Runs iteratively to handle multi-level cascading (lists → messages → message_*).
+    Mutates stream_ids in place.
+    """
+    changed = True
+    while changed:
+        changed = False
+        for child, parent in STREAM_DEPENDENCIES.items():
+            if child in stream_ids and parent not in stream_ids:
+                LOGGER.warning(
+                    "Stream '%s' excluded from catalog because its parent "
+                    "stream '%s' is not accessible.",
+                    child,
+                    parent,
+                )
+                stream_ids.discard(child)
+                inaccessible.add(child)
+                changed = True
 
 
 def discover(ctx):
-    check_credentials_are_authorized(ctx)
+    inaccessible = set()
+    accessible_stream_ids = set(schemas.stream_ids)
+
+    # Probe root-level streams that can be checked without data IDs
+    for stream_id, service_method in _PROBEABLE_STREAMS.items():
+        try:
+            getattr(ctx.client.service, service_method)()
+        except Fault as e:
+            LOGGER.warning(
+                "Stream '%s' does not have read permission, excluding from catalog: %s",
+                stream_id,
+                e,
+            )
+            accessible_stream_ids.discard(stream_id)
+            inaccessible.add(stream_id)
+
+    _prune_inaccessible_children(accessible_stream_ids, inaccessible)
+
+    if not accessible_stream_ids:
+        raise ListrakForbiddenError(
+            "HTTP-error-code: 403, Error: The account credentials supplied do not have "
+            "'read' access to any of the streams supported by the tap. Data collection "
+            "cannot be initiated due to lack of permissions."
+        )
+
+    if inaccessible:
+        LOGGER.warning(
+            "The account credentials supplied do not have 'read' access to the "
+            "following stream(s): %s. These streams have been excluded from the catalog.",
+            ", ".join(sorted(inaccessible)),
+        )
+
     catalog = Catalog([])
 
     for tap_stream_id in schemas.stream_ids:
+        if tap_stream_id not in accessible_stream_ids:
+            continue
+
         schema_dict = schemas.load_schema(tap_stream_id)
         schema = Schema.from_dict(schema_dict)
 

--- a/tap_listrak/__init__.py
+++ b/tap_listrak/__init__.py
@@ -79,18 +79,19 @@ def discover(ctx):
     inaccessible = set()
     accessible_stream_ids = set(schemas.stream_ids)
 
-    # Probe root-level streams that can be checked without data IDs
-    for stream_id, service_method in _PROBEABLE_STREAMS.items():
-        try:
-            getattr(ctx.client.service, service_method)()
-        except Fault as e:
-            LOGGER.warning(
-                "Stream '%s' does not have read permission, excluding from catalog: %s",
-                stream_id,
-                e,
-            )
-            accessible_stream_ids.discard(stream_id)
-            inaccessible.add(stream_id)
+    # Probe root-level streams that can be checked without data IDs.
+    # Reuse check_credentials_are_authorized() so probe logic stays in one place.
+    try:
+        check_credentials_are_authorized(ctx)
+    except ListrakForbiddenError as e:
+        stream_id = next(iter(_PROBEABLE_STREAMS))
+        LOGGER.warning(
+            "Stream '%s' does not have read permission, excluding from catalog: %s",
+            stream_id,
+            e,
+        )
+        accessible_stream_ids.discard(stream_id)
+        inaccessible.add(stream_id)
 
     _prune_inaccessible_children(accessible_stream_ids, inaccessible)
 

--- a/tap_listrak/__init__.py
+++ b/tap_listrak/__init__.py
@@ -35,10 +35,55 @@ _MESSAGE_SUBSTREAM_ENDPOINTS = {
 }
 
 
+def _log_unauthorized_stream(stream_name, exc):
+    LOGGER.warning(
+        "Excluding unauthorized stream '%s' from catalog. HTTP-Error-Message: '%s'",
+        stream_name,
+        str(exc)
+    )
+
+
+def _build_catalog_metadata(schema_dict, tap_stream_id):
+    mdata = metadata.get_standard_metadata(
+        schema_dict,
+        replication_method=schemas.REPLICATION_METHODS[tap_stream_id],
+        key_properties=schemas.PK_FIELDS[tap_stream_id]
+    )
+    mdata = metadata.to_map(mdata)
+
+    # `lists` and `messages` are required for their substreams.
+    if tap_stream_id in ['lists', 'messages']:
+        mdata = metadata.write(mdata, (), 'inclusion', 'automatic')
+
+    for field_name in schema_dict['properties'].keys():
+        mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
+
+    if parent_stream := STREAM_DEPENDENCIES.get(tap_stream_id):
+        mdata = metadata.write(mdata, (), 'parent-tap-stream-id', parent_stream)
+
+    return mdata
+
+
+def get_schemas_with_metadata():
+    """
+    Return stream schemas and stream metadata keyed by stream id.
+    """
+    schema_map = {}
+    field_metadata = {}
+
+    for tap_stream_id in schemas.stream_ids:
+        schema_dict = schemas.load_schema(tap_stream_id)
+        schema_map[tap_stream_id] = schema_dict
+        field_metadata[tap_stream_id] = _build_catalog_metadata(schema_dict, tap_stream_id)
+
+    return schema_map, field_metadata
+
+
 def check_credentials_are_authorized(ctx):
     """
     Probe the 'lists' stream via GetContactListCollection.
-    Returns the first ListID from the response, or None if the account has no lists.
+    Returns the first ListID from the response, or None when the account has
+    no lists but the credentials are still authorized for the stream.
     Raises ListrakForbiddenError if credentials lack read access.
     """
     try:
@@ -46,16 +91,18 @@ def check_credentials_are_authorized(ctx):
         LOGGER.info("Stream 'lists' is accessible.")
         lists = response or []
         if not lists:
-            raise ListrakForbiddenError(
-                "HTTP-error-code: 403, Error: Credentials are valid but "
-                "no lists were found in the account."
+            LOGGER.warning(
+                "Stream 'lists' is accessible, but the account has no lists. "
+                "Excluding dependent streams from catalog because no ListID is available."
             )
+            return None
         return lists[0].ListID
-    except Fault as e:
+    except Fault as exc:
+        _log_unauthorized_stream('lists', exc)
         raise ListrakForbiddenError(
             "HTTP-error-code: 403, Error: The credentials do not have "
-            "'read' access to any supported streams: %s" % e
-        ) from e
+            "'read' access to stream 'lists'. HTTP-Error-Message: '%s'" % str(exc)
+        ) from exc
 
 
 def _probe_list_dependent(ctx, stream_id, list_id):
@@ -63,8 +110,6 @@ def _probe_list_dependent(ctx, stream_id, list_id):
     Probe 'messages' or 'subscribed_contacts' using a real ListID.
     Uses a 365-day look-back to maximise the chance of finding message data.
     Returns (is_accessible, msg_id_or_None).
-      - For 'messages': msg_id is the first MsgID found in the response (or None).
-      - For 'subscribed_contacts': msg_id is always None.
     """
     now = pendulum.now("UTC")
     start = now.subtract(days=365)
@@ -83,18 +128,18 @@ def _probe_list_dependent(ctx, stream_id, list_id):
             except (TypeError, KeyError, IndexError):
                 pass
             return True, msg_id
-        elif stream_id == 'subscribed_contacts':
+
+        if stream_id == 'subscribed_contacts':
             ctx.client.service.ReportRangeSubscribedContacts(
                 ListID=list_id, StartDate=start, EndDate=now, Page=1
             )
             LOGGER.info("Stream 'subscribed_contacts' is accessible.")
             return True, None
-    except Fault as e:
-        LOGGER.warning(
-            "Stream '%s' does not have read permission, excluding from catalog: %s",
-            stream_id, e,
-        )
+    except Fault as exc:
+        _log_unauthorized_stream(stream_id, exc)
         return False, None
+
+    return False, None
 
 
 def _probe_message_substream(ctx, stream_id, msg_id):
@@ -112,109 +157,115 @@ def _probe_message_substream(ctx, stream_id, msg_id):
         getattr(ctx.client.service, endpoint)(**kwargs)
         LOGGER.info("Stream '%s' is accessible.", stream_id)
         return True
-    except Fault as e:
-        LOGGER.warning(
-            "Stream '%s' does not have read permission, excluding from catalog: %s",
-            stream_id, e,
-        )
+    except Fault as exc:
+        _log_unauthorized_stream(stream_id, exc)
         return False
 
 
-def _prune_inaccessible_children(stream_ids, inaccessible):
+def _prune_inaccessible_children(schema_map, field_metadata):
     """
-    Cascade-remove child streams whose parent was marked inaccessible.
-    Used when messages was blocked (without a MsgID probe) to ensure
-    all message_* streams are also removed.
-    Runs iteratively to handle multi-level chains.
+    Remove child streams when their parent stream is excluded.
+    Mutates schema_map and field_metadata in place.
     """
     changed = True
     while changed:
         changed = False
         for child, parent in STREAM_DEPENDENCIES.items():
-            if child in stream_ids and parent not in stream_ids:
+            if child in schema_map and parent not in schema_map:
                 LOGGER.warning(
                     "Stream '%s' excluded from catalog because its parent "
                     "stream '%s' is not accessible.",
-                    child, parent,
+                    child,
+                    parent,
                 )
-                stream_ids.discard(child)
-                inaccessible.add(child)
+                schema_map.pop(child, None)
+                field_metadata.pop(child, None)
                 changed = True
 
 
-def discover(ctx):
-    inaccessible = set()
-    accessible_stream_ids = set(schemas.stream_ids)
+def _apply_access_checks(ctx, schema_map, field_metadata):
+    """
+    Probe stream access and remove inaccessible streams from discovery output.
+    Mutates schema_map and field_metadata in place.
+    """
+    inaccessible_streams = []
 
-    # Step 1: probe 'lists' — raises immediately if inaccessible or empty.
+    # Step 1: probe `lists`.
     list_id = check_credentials_are_authorized(ctx)
 
-    # Step 2: probe 'messages' and 'subscribed_contacts' with the ListID.
+    if list_id is None:
+        for stream_id in ('messages', 'subscribed_contacts'):
+            if stream_id in schema_map:
+                schema_map.pop(stream_id, None)
+                field_metadata.pop(stream_id, None)
+        _prune_inaccessible_children(schema_map, field_metadata)
+        return
+
+    # Step 2: probe list-dependent streams.
     messages_accessible, msg_id = _probe_list_dependent(ctx, 'messages', list_id)
-    if not messages_accessible:
-        accessible_stream_ids.discard('messages')
-        inaccessible.add('messages')
-        _prune_inaccessible_children(accessible_stream_ids, inaccessible)
+    if not messages_accessible and 'messages' in schema_map:
+        inaccessible_streams.append('messages')
+        schema_map.pop('messages', None)
+        field_metadata.pop('messages', None)
 
-    sc_accessible, _ = _probe_list_dependent(ctx, 'subscribed_contacts', list_id)
-    if not sc_accessible:
-        accessible_stream_ids.discard('subscribed_contacts')
-        inaccessible.add('subscribed_contacts')
+    contacts_accessible, _ = _probe_list_dependent(ctx, 'subscribed_contacts', list_id)
+    if not contacts_accessible and 'subscribed_contacts' in schema_map:
+        inaccessible_streams.append('subscribed_contacts')
+        schema_map.pop('subscribed_contacts', None)
+        field_metadata.pop('subscribed_contacts', None)
 
-    # Step 3: probe message_* sub-streams with the MsgID.
+    # Step 3: probe message sub-streams when we have a probe MsgID.
     if messages_accessible and msg_id is not None:
         for stream_id in _MESSAGE_SUBSTREAM_ENDPOINTS:
-            if not _probe_message_substream(ctx, stream_id, msg_id):
-                accessible_stream_ids.discard(stream_id)
-                inaccessible.add(stream_id)
+            if stream_id in schema_map and not _probe_message_substream(ctx, stream_id, msg_id):
+                inaccessible_streams.append(stream_id)
+                schema_map.pop(stream_id, None)
+                field_metadata.pop(stream_id, None)
     elif messages_accessible:
         LOGGER.warning(
             "No messages found in account history; message_* sub-streams "
             "included in catalog without access check."
         )
 
-    if inaccessible:
+    _prune_inaccessible_children(schema_map, field_metadata)
+
+    if not schema_map:
+        raise ListrakForbiddenError(
+            "HTTP-error-code: 403, Error: The credentials do not have 'read' "
+            "access to any supported streams."
+        )
+
+    if inaccessible_streams:
         LOGGER.warning(
             "No 'read' access to stream(s): %s. Excluded from catalog.",
-            ", ".join(sorted(inaccessible)),
+            ", ".join(sorted(set(inaccessible_streams))),
         )
+
+
+def discover(ctx):
+    """
+    Run discovery and exclude inaccessible streams from the generated catalog.
+    """
+    schema_map, field_metadata = get_schemas_with_metadata()
+    _apply_access_checks(ctx, schema_map, field_metadata)
 
     catalog = Catalog([])
-
     for tap_stream_id in schemas.stream_ids:
-        if tap_stream_id not in accessible_stream_ids:
+        if tap_stream_id not in schema_map:
             continue
 
-        schema_dict = schemas.load_schema(tap_stream_id)
+        schema_dict = schema_map[tap_stream_id]
         schema = Schema.from_dict(schema_dict)
-
-        mdata = metadata.get_standard_metadata(
-            schema_dict,
-            replication_method=schemas.REPLICATION_METHODS[tap_stream_id],
-            key_properties=schemas.PK_FIELDS[tap_stream_id]
-        )
-
-        mdata = metadata.to_map(mdata)
-
-        # NB: `lists` and `messages` are required for their substreams.
-        # This is an approximation of the initial functionality using
-        # metadata, which marked them as `selected=True` in the schema.
-        if tap_stream_id in ['lists', 'messages']:
-            mdata = metadata.write(mdata, (), 'inclusion', 'automatic')
-
-        for field_name in schema_dict['properties'].keys():
-            mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
-
-        if parent_stream := STREAM_DEPENDENCIES.get(tap_stream_id):
-            mdata = metadata.write(mdata, (), 'parent-tap-stream-id', parent_stream)
+        mdata = field_metadata[tap_stream_id]
 
         catalog.streams.append(CatalogEntry(
             stream=tap_stream_id,
             tap_stream_id=tap_stream_id,
             key_properties=schemas.PK_FIELDS[tap_stream_id],
             schema=schema,
-            metadata = metadata.to_list(mdata)
+            metadata=metadata.to_list(mdata)
         ))
+
     return catalog
 
 

--- a/tap_listrak/__init__.py
+++ b/tap_listrak/__init__.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import pendulum
 import singer
 from singer import utils, metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
@@ -12,7 +13,6 @@ REQUIRED_CONFIG_KEYS = ["start_date", "username", "password"]
 LOGGER = singer.get_logger()
 
 # Maps each child stream to its direct parent stream.
-# Used to cascade-remove children when a parent stream is inaccessible.
 STREAM_DEPENDENCIES = {
     'messages': 'lists',
     'message_bounces': 'messages',
@@ -24,40 +24,104 @@ STREAM_DEPENDENCIES = {
     'subscribed_contacts': 'lists'
 }
 
-# Only 'lists' can be probed during discovery without needing data IDs from
-# a prior API call. Child streams (messages, message_*, subscribed_contacts)
-# all require ListID or MsgID obtained at sync time.
-_PROBEABLE_STREAMS = {
-    'lists': 'GetContactListCollection',
+# SOAP endpoints for streams requiring a MsgID.
+_MESSAGE_SUBSTREAM_ENDPOINTS = {
+    'message_clicks':  'ReportRangeMessageContactClick',
+    'message_opens':   'ReportRangeMessageContactOpen',
+    'message_reads':   'ReportRangeMessageContactRead',
+    'message_unsubs':  'ReportRangeMessageContactRemoval',
+    'message_bounces': 'ReportRangeMessageContactBounces',
+    'message_sends':   'ReportMessageContactSent',
 }
 
 
 def check_credentials_are_authorized(ctx):
     """
-    Probe the 'lists' stream via GetContactListCollection to verify the
-    account credentials have read access to the Listrak SOAP API.
-
-    A zeep.Fault exception indicates the credentials lack sufficient access.
-    Raises ListrakForbiddenError if the probe fails.
-
-    Since 'lists' is the root dependency for all streams, a failed probe
-    means no data can be collected.
+    Probe the 'lists' stream via GetContactListCollection.
+    Returns the first ListID from the response, or None if the account has no lists.
+    Raises ListrakForbiddenError if credentials lack read access.
     """
     try:
-        ctx.client.service.GetContactListCollection()
-        LOGGER.info("Listrak credentials verified: 'lists' stream is accessible.")
+        response = ctx.client.service.GetContactListCollection()
+        LOGGER.info("Stream 'lists' is accessible.")
+        lists = response or []
+        return lists[0].ListID if lists else None
     except Fault as e:
         raise ListrakForbiddenError(
-            "Error: The account credentials supplied do not have 'read' access "
-            "to the Listrak API. Data collection cannot be initiated: {}".format(e)
+            "HTTP-error-code: 403, Error: The account credentials supplied do not have "
+            "'read' access to any of the streams supported by the tap. "
+            "Data collection cannot be initiated: {}".format(e)
         ) from e
+
+
+def _probe_list_dependent(ctx, stream_id, list_id):
+    """
+    Probe 'messages' or 'subscribed_contacts' using a real ListID.
+    Uses a 365-day look-back to maximise the chance of finding message data.
+    Returns (is_accessible, msg_id_or_None).
+      - For 'messages': msg_id is the first MsgID found in the response (or None).
+      - For 'subscribed_contacts': msg_id is always None.
+    """
+    now = pendulum.now("UTC")
+    start = now.subtract(days=365)
+    try:
+        if stream_id == 'messages':
+            response = ctx.client.service.ReportListMessageActivity(
+                ListID=list_id, StartDate=start, EndDate=now, IncludeTestMessages=True
+            )
+            LOGGER.info("Stream 'messages' is accessible.")
+            msg_id = None
+            try:
+                act_result = response["ReportListMessageActivityResult"]
+                ws_messages = act_result["WSMessageActivity"] if act_result else None
+                if ws_messages:
+                    msg_id = ws_messages[0]["MsgID"]
+            except (TypeError, KeyError, IndexError):
+                pass
+            return True, msg_id
+        elif stream_id == 'subscribed_contacts':
+            ctx.client.service.ReportRangeSubscribedContacts(
+                ListID=list_id, StartDate=start, EndDate=now, Page=1
+            )
+            LOGGER.info("Stream 'subscribed_contacts' is accessible.")
+            return True, None
+    except Fault as e:
+        LOGGER.warning(
+            "Stream '%s' does not have read permission, excluding from catalog: %s",
+            stream_id, e,
+        )
+        return False, None
+
+
+def _probe_message_substream(ctx, stream_id, msg_id):
+    """
+    Probe a message_* sub-stream using a real MsgID.
+    Returns True if accessible, False if a Fault is raised.
+    """
+    now = pendulum.now("UTC")
+    start = now.subtract(days=365)
+    endpoint = _MESSAGE_SUBSTREAM_ENDPOINTS[stream_id]
+    kwargs = {'MsgID': msg_id, 'Page': 1}
+    if stream_id != 'message_sends':
+        kwargs.update({'StartDate': start, 'EndDate': now})
+    try:
+        getattr(ctx.client.service, endpoint)(**kwargs)
+        LOGGER.info("Stream '%s' is accessible.", stream_id)
+        return True
+    except Fault as e:
+        LOGGER.warning(
+            "Stream '%s' does not have read permission, excluding from catalog: %s",
+            stream_id, e,
+        )
+        return False
 
 
 def _prune_inaccessible_children(stream_ids, inaccessible):
     """
-    Remove child streams from stream_ids whose parent stream is inaccessible.
-    Runs iteratively to handle multi-level cascading (lists → messages → message_*).
-    Mutates stream_ids in place.
+    Cascade-remove child streams whose parent was marked inaccessible.
+    Used when messages was blocked (without a MsgID probe) to ensure
+    all message_* streams are also removed.
+    Runs iteratively to handle multi-level chains.
     """
     changed = True
     while changed:
@@ -67,8 +131,7 @@ def _prune_inaccessible_children(stream_ids, inaccessible):
                 LOGGER.warning(
                     "Stream '%s' excluded from catalog because its parent "
                     "stream '%s' is not accessible.",
-                    child,
-                    parent,
+                    child, parent,
                 )
                 stream_ids.discard(child)
                 inaccessible.add(child)
@@ -79,28 +142,39 @@ def discover(ctx):
     inaccessible = set()
     accessible_stream_ids = set(schemas.stream_ids)
 
-    # Probe root-level streams that can be checked without data IDs.
-    # Reuse check_credentials_are_authorized() so probe logic stays in one place.
-    try:
-        check_credentials_are_authorized(ctx)
-    except ListrakForbiddenError as e:
-        stream_id = next(iter(_PROBEABLE_STREAMS))
+    # Step 1: probe 'lists' — raises immediately if inaccessible.
+    list_id = check_credentials_are_authorized(ctx)
+
+    if list_id is not None:
+        # Step 2: probe 'messages' and 'subscribed_contacts' with the ListID.
+        messages_accessible, msg_id = _probe_list_dependent(ctx, 'messages', list_id)
+        if not messages_accessible:
+            accessible_stream_ids.discard('messages')
+            inaccessible.add('messages')
+
+        sc_accessible, _ = _probe_list_dependent(ctx, 'subscribed_contacts', list_id)
+        if not sc_accessible:
+            accessible_stream_ids.discard('subscribed_contacts')
+            inaccessible.add('subscribed_contacts')
+
+        # Step 3: probe message_* sub-streams with the MsgID.
+        if messages_accessible and msg_id is not None:
+            for stream_id in _MESSAGE_SUBSTREAM_ENDPOINTS:
+                if not _probe_message_substream(ctx, stream_id, msg_id):
+                    accessible_stream_ids.discard(stream_id)
+                    inaccessible.add(stream_id)
+        elif messages_accessible:
+            LOGGER.warning(
+                "No messages found in account history; skipping access check for "
+                "message_* sub-streams — they will be included in the catalog."
+            )
+    else:
         LOGGER.warning(
-            "Stream '%s' does not have read permission, excluding from catalog: %s",
-            stream_id,
-            e,
+            "No lists found in the account; skipping access check for child streams."
         )
-        accessible_stream_ids.discard(stream_id)
-        inaccessible.add(stream_id)
 
+    # Cascade: remove message_* children if messages was excluded.
     _prune_inaccessible_children(accessible_stream_ids, inaccessible)
-
-    if not accessible_stream_ids:
-        raise ListrakForbiddenError(
-            "HTTP-error-code: 403, Error: The account credentials supplied do not have "
-            "'read' access to any of the streams supported by the tap. Data collection "
-            "cannot be initiated due to lack of permissions."
-        )
 
     if inaccessible:
         LOGGER.warning(

--- a/tap_listrak/http.py
+++ b/tap_listrak/http.py
@@ -8,6 +8,10 @@ LOGGER = singer.get_logger()
 
 WSDL = "https://webservices.listrak.com/v31/IntegrationService.asmx?wsdl"
 
+
+class ListrakForbiddenError(Exception):
+    """Raised when SOAP credentials lack read access to a Listrak stream."""
+
 def get_client(config):
     client = zeep.Client(wsdl=WSDL)
     elem = client.get_element("{http://webservices.listrak.com/v31/}WSUser")

--- a/tap_listrak/http.py
+++ b/tap_listrak/http.py
@@ -12,6 +12,7 @@ WSDL = "https://webservices.listrak.com/v31/IntegrationService.asmx?wsdl"
 class ListrakForbiddenError(Exception):
     """Raised when SOAP credentials lack read access to a Listrak stream."""
 
+
 def get_client(config):
     client = zeep.Client(wsdl=WSDL)
     elem = client.get_element("{http://webservices.listrak.com/v31/}WSUser")

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -16,6 +16,15 @@ class ListrakAutomaticFieldsTest(ListrakBaseTest, unittest.TestCase):
         """Helper to run discover with a mocked Context."""
         ctx = MagicMock(spec=Context)
         ctx.client = MagicMock()  # allow SOAP probe call in discover()
+        # Stub minimal SOAP responses for deterministic testing
+        mock_list = MagicMock()
+        mock_list.ListID = 1
+        ctx.client.service.GetContactListCollection.return_value = [mock_list]
+        mock_msg = MagicMock()
+        mock_msg.__getitem__ = lambda s, k: 1 if k == 'MsgID' else None
+        ctx.client.service.ReportListMessageActivity.return_value = {
+            'ReportListMessageActivityResult': {'WSMessageActivity': [mock_msg]}
+        }
         ctx.config = self.get_mock_config()
         return discover(ctx)
 

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -15,6 +15,7 @@ class ListrakAutomaticFieldsTest(ListrakBaseTest, unittest.TestCase):
     def _get_catalog(self):
         """Helper to run discover with a mocked Context."""
         ctx = MagicMock(spec=Context)
+        ctx.client = MagicMock()  # allow SOAP probe call in discover()
         ctx.config = self.get_mock_config()
         return discover(ctx)
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -14,6 +14,7 @@ class ListrakDiscoveryTest(ListrakBaseTest, unittest.TestCase):
     def _get_catalog(self):
         """Helper to run discover with a mocked Context."""
         ctx = MagicMock(spec=Context)
+        ctx.client = MagicMock()  # allow SOAP probe call in discover()
         ctx.config = self.get_mock_config()
         return discover(ctx)
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -15,6 +15,15 @@ class ListrakDiscoveryTest(ListrakBaseTest, unittest.TestCase):
         """Helper to run discover with a mocked Context."""
         ctx = MagicMock(spec=Context)
         ctx.client = MagicMock()  # allow SOAP probe call in discover()
+        # Stub minimal SOAP responses for deterministic testing
+        mock_list = MagicMock()
+        mock_list.ListID = 1
+        ctx.client.service.GetContactListCollection.return_value = [mock_list]
+        mock_msg = MagicMock()
+        mock_msg.__getitem__ = lambda s, k: 1 if k == 'MsgID' else None
+        ctx.client.service.ReportListMessageActivity.return_value = {
+            'ReportListMessageActivityResult': {'WSMessageActivity': [mock_msg]}
+        }
         ctx.config = self.get_mock_config()
         return discover(ctx)
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,15 +1,12 @@
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 from zeep.exceptions import Fault
 from tap_listrak import schemas, discover
 from tap_listrak.__init__ import (
-    STREAM_DEPENDENCIES,
-    _PROBEABLE_STREAMS,
     _prune_inaccessible_children,
     check_credentials_are_authorized,
 )
 from tap_listrak.http import ListrakForbiddenError
-from tap_listrak.context import Context
 from singer import metadata
 
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,8 +1,22 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, call
+from zeep.exceptions import Fault
 from tap_listrak import schemas, discover
+from tap_listrak.__init__ import (
+    STREAM_DEPENDENCIES,
+    _PROBEABLE_STREAMS,
+    _prune_inaccessible_children,
+    check_credentials_are_authorized,
+)
+from tap_listrak.http import ListrakForbiddenError
 from tap_listrak.context import Context
 from singer import metadata
+
+
+# ---------------------------------------------------------------------------
+# Note: existing catalog-structure test classes use MagicMock() (no spec) so
+# that ctx.client is auto-created and the SOAP probe in discover() succeeds.
+# ---------------------------------------------------------------------------
 
 
 class TestDiscoverMetadata(unittest.TestCase):
@@ -10,7 +24,7 @@ class TestDiscoverMetadata(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.ctx = MagicMock(spec=Context)
+        self.ctx = MagicMock()  # no spec: client attribute auto-created for SOAP probe
         self.ctx.config = {
             'start_date': '2026-01-01T00:00:00Z',
             'username': 'test_user',
@@ -265,7 +279,7 @@ class TestStreamDependencyHierarchy(unittest.TestCase):
             'properties': {'id': {'type': 'integer'}}
         }
 
-        ctx = MagicMock(spec=Context)
+        ctx = MagicMock()  # no spec: client auto-created for SOAP probe
         catalog = discover(ctx)
 
         # lists has no parent
@@ -291,7 +305,7 @@ class TestStreamDependencyHierarchy(unittest.TestCase):
             'properties': {'id': {'type': 'integer'}}
         }
 
-        ctx = MagicMock(spec=Context)
+        ctx = MagicMock()  # no spec: client auto-created for SOAP probe
         catalog = discover(ctx)
 
         # lists and messages should have automatic inclusion
@@ -313,4 +327,141 @@ class TestStreamDependencyHierarchy(unittest.TestCase):
             # The stream-level inclusion should be None or 'available'
             self.assertNotEqual(inclusion, 'automatic',
                               f"{stream_id} should not have automatic stream-level inclusion")
+
+
+# ---------------------------------------------------------------------------
+# Tests for check_credentials_are_authorized
+# ---------------------------------------------------------------------------
+
+class TestCheckCredentialsAuthorized(unittest.TestCase):
+
+    def _make_ctx(self, fault=None):
+        ctx = MagicMock()  # no spec: client attribute auto-created
+        if fault:
+            ctx.client.service.GetContactListCollection.side_effect = fault
+        return ctx
+
+    def test_succeeds_when_lists_accessible(self):
+        """No exception raised when GetContactListCollection returns successfully."""
+        ctx = self._make_ctx()
+        try:
+            check_credentials_are_authorized(ctx)
+        except ListrakForbiddenError:
+            self.fail("check_credentials_are_authorized raised unexpectedly")
+
+    def test_raises_forbidden_on_fault(self):
+        """ListrakForbiddenError raised when SOAP service returns a Fault."""
+        ctx = self._make_ctx(fault=Fault("Access denied"))
+        with self.assertRaises(ListrakForbiddenError):
+            check_credentials_are_authorized(ctx)
+
+    def test_forbidden_error_contains_fault_message(self):
+        """The raised error message includes the original Fault message."""
+        ctx = self._make_ctx(fault=Fault("InvalidLogonAttempt"))
+        with self.assertRaises(ListrakForbiddenError) as cm:
+            check_credentials_are_authorized(ctx)
+        self.assertIn("InvalidLogonAttempt", str(cm.exception))
+
+    def test_probes_get_contact_list_collection(self):
+        """Verifies the exact SOAP method used for the access probe."""
+        ctx = self._make_ctx()
+        check_credentials_are_authorized(ctx)
+        ctx.client.service.GetContactListCollection.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests for _prune_inaccessible_children
+# ---------------------------------------------------------------------------
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+
+    def test_messages_removed_when_lists_inaccessible(self):
+        accessible = set(schemas.stream_ids) - {'lists'}
+        inaccessible = {'lists'}
+        _prune_inaccessible_children(accessible, inaccessible)
+        self.assertNotIn('messages', accessible)
+        self.assertNotIn('subscribed_contacts', accessible)
+
+    def test_message_substreams_cascade_when_lists_inaccessible(self):
+        """Removing lists cascades to messages, then to all message_* streams."""
+        accessible = set(schemas.stream_ids) - {'lists'}
+        inaccessible = {'lists'}
+        _prune_inaccessible_children(accessible, inaccessible)
+        for child in ('message_clicks', 'message_opens', 'message_reads',
+                      'message_sends', 'message_unsubs', 'message_bounces'):
+            self.assertNotIn(child, accessible)
+
+    def test_message_substreams_removed_when_messages_inaccessible(self):
+        accessible = set(schemas.stream_ids) - {'messages'}
+        inaccessible = {'messages'}
+        _prune_inaccessible_children(accessible, inaccessible)
+        for child in ('message_clicks', 'message_opens', 'message_reads',
+                      'message_sends', 'message_unsubs', 'message_bounces'):
+            self.assertNotIn(child, accessible)
+
+    def test_lists_kept_when_no_parent_absent(self):
+        accessible = set(schemas.stream_ids)
+        inaccessible = set()
+        _prune_inaccessible_children(accessible, inaccessible)
+        self.assertIn('lists', accessible)
+        self.assertIn('messages', accessible)
+
+    def test_pruned_streams_added_to_inaccessible(self):
+        accessible = set(schemas.stream_ids) - {'lists'}
+        inaccessible = {'lists'}
+        _prune_inaccessible_children(accessible, inaccessible)
+        self.assertIn('messages', inaccessible)
+        self.assertIn('subscribed_contacts', inaccessible)
+
+
+# ---------------------------------------------------------------------------
+# Tests for discover() access-check integration
+# ---------------------------------------------------------------------------
+
+class TestDiscoverAccessChecks(unittest.TestCase):
+
+    def _make_ctx(self, fault_on_lists=False):
+        ctx = MagicMock()  # no spec: client attribute auto-created
+        if fault_on_lists:
+            ctx.client.service.GetContactListCollection.side_effect = Fault("Access denied")
+        return ctx
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_discover_all_streams_when_lists_accessible(self, mock_load_schema):
+        mock_load_schema.return_value = {'type': 'object', 'properties': {'ListID': {'type': 'integer'}}}
+        ctx = self._make_ctx()
+        catalog = discover(ctx)
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertEqual(stream_ids, set(schemas.stream_ids))
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_discover_raises_when_lists_inaccessible(self, mock_load_schema):
+        mock_load_schema.return_value = {'type': 'object', 'properties': {'ListID': {'type': 'integer'}}}
+        ctx = self._make_ctx(fault_on_lists=True)
+        with self.assertRaises(ListrakForbiddenError):
+            discover(ctx)
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_discover_excludes_lists_and_all_children_when_forbidden(self, mock_load_schema):
+        """When lists is forbidden, catalog must be empty → ListrakForbiddenError raised."""
+        mock_load_schema.return_value = {'type': 'object', 'properties': {'ListID': {'type': 'integer'}}}
+        ctx = self._make_ctx(fault_on_lists=True)
+        with self.assertRaises(ListrakForbiddenError) as cm:
+            discover(ctx)
+        self.assertIn("403", str(cm.exception))
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_discover_probes_lists_endpoint(self, mock_load_schema):
+        mock_load_schema.return_value = {'type': 'object', 'properties': {'ListID': {'type': 'integer'}}}
+        ctx = self._make_ctx()
+        discover(ctx)
+        ctx.client.service.GetContactListCollection.assert_called_once()
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_discover_does_not_skip_schema_load_for_accessible_streams(self, mock_load_schema):
+        """All accessible stream schemas must be loaded during discovery."""
+        mock_load_schema.return_value = {'type': 'object', 'properties': {'id': {'type': 'integer'}}}
+        ctx = self._make_ctx()
+        discover(ctx)
+        self.assertEqual(mock_load_schema.call_count, len(schemas.stream_ids))
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -3,8 +3,10 @@ from unittest.mock import MagicMock, patch
 from zeep.exceptions import Fault
 from tap_listrak import schemas, discover
 from tap_listrak.__init__ import (
-    _prune_inaccessible_children,
     check_credentials_are_authorized,
+    _probe_list_dependent,
+    _probe_message_substream,
+    _MESSAGE_SUBSTREAM_ENDPOINTS,
 )
 from tap_listrak.http import ListrakForbiddenError
 from singer import metadata
@@ -332,83 +334,42 @@ class TestStreamDependencyHierarchy(unittest.TestCase):
 
 class TestCheckCredentialsAuthorized(unittest.TestCase):
 
-    def _make_ctx(self, fault=None):
-        ctx = MagicMock()  # no spec: client attribute auto-created
+    def _make_ctx(self, fault=None, list_id=42):
+        ctx = MagicMock()
         if fault:
             ctx.client.service.GetContactListCollection.side_effect = fault
+        else:
+            mock_list = MagicMock()
+            mock_list.ListID = list_id
+            ctx.client.service.GetContactListCollection.return_value = [mock_list]
         return ctx
 
-    def test_succeeds_when_lists_accessible(self):
-        """No exception raised when GetContactListCollection returns successfully."""
-        ctx = self._make_ctx()
-        try:
-            check_credentials_are_authorized(ctx)
-        except ListrakForbiddenError:
-            self.fail("check_credentials_are_authorized raised unexpectedly")
+    def test_returns_list_id_when_lists_accessible(self):
+        ctx = self._make_ctx(list_id=7)
+        result = check_credentials_are_authorized(ctx)
+        self.assertEqual(result, 7)
+
+    def test_returns_none_when_lists_empty(self):
+        ctx = MagicMock()
+        ctx.client.service.GetContactListCollection.return_value = []
+        self.assertIsNone(check_credentials_are_authorized(ctx))
 
     def test_raises_forbidden_on_fault(self):
-        """ListrakForbiddenError raised when SOAP service returns a Fault."""
         ctx = self._make_ctx(fault=Fault("Access denied"))
         with self.assertRaises(ListrakForbiddenError):
             check_credentials_are_authorized(ctx)
 
-    def test_forbidden_error_contains_fault_message(self):
-        """The raised error message includes the original Fault message."""
+    def test_forbidden_error_contains_403_and_fault_message(self):
         ctx = self._make_ctx(fault=Fault("InvalidLogonAttempt"))
         with self.assertRaises(ListrakForbiddenError) as cm:
             check_credentials_are_authorized(ctx)
+        self.assertIn("403", str(cm.exception))
         self.assertIn("InvalidLogonAttempt", str(cm.exception))
 
     def test_probes_get_contact_list_collection(self):
-        """Verifies the exact SOAP method used for the access probe."""
         ctx = self._make_ctx()
         check_credentials_are_authorized(ctx)
         ctx.client.service.GetContactListCollection.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# Tests for _prune_inaccessible_children
-# ---------------------------------------------------------------------------
-
-class TestPruneInaccessibleChildren(unittest.TestCase):
-
-    def test_messages_removed_when_lists_inaccessible(self):
-        accessible = set(schemas.stream_ids) - {'lists'}
-        inaccessible = {'lists'}
-        _prune_inaccessible_children(accessible, inaccessible)
-        self.assertNotIn('messages', accessible)
-        self.assertNotIn('subscribed_contacts', accessible)
-
-    def test_message_substreams_cascade_when_lists_inaccessible(self):
-        """Removing lists cascades to messages, then to all message_* streams."""
-        accessible = set(schemas.stream_ids) - {'lists'}
-        inaccessible = {'lists'}
-        _prune_inaccessible_children(accessible, inaccessible)
-        for child in ('message_clicks', 'message_opens', 'message_reads',
-                      'message_sends', 'message_unsubs', 'message_bounces'):
-            self.assertNotIn(child, accessible)
-
-    def test_message_substreams_removed_when_messages_inaccessible(self):
-        accessible = set(schemas.stream_ids) - {'messages'}
-        inaccessible = {'messages'}
-        _prune_inaccessible_children(accessible, inaccessible)
-        for child in ('message_clicks', 'message_opens', 'message_reads',
-                      'message_sends', 'message_unsubs', 'message_bounces'):
-            self.assertNotIn(child, accessible)
-
-    def test_lists_kept_when_no_parent_absent(self):
-        accessible = set(schemas.stream_ids)
-        inaccessible = set()
-        _prune_inaccessible_children(accessible, inaccessible)
-        self.assertIn('lists', accessible)
-        self.assertIn('messages', accessible)
-
-    def test_pruned_streams_added_to_inaccessible(self):
-        accessible = set(schemas.stream_ids) - {'lists'}
-        inaccessible = {'lists'}
-        _prune_inaccessible_children(accessible, inaccessible)
-        self.assertIn('messages', inaccessible)
-        self.assertIn('subscribed_contacts', inaccessible)
 
 
 # ---------------------------------------------------------------------------
@@ -417,48 +378,176 @@ class TestPruneInaccessibleChildren(unittest.TestCase):
 
 class TestDiscoverAccessChecks(unittest.TestCase):
 
-    def _make_ctx(self, fault_on_lists=False):
-        ctx = MagicMock()  # no spec: client attribute auto-created
+    _SIMPLE_SCHEMA = {'type': 'object', 'properties': {'ListID': {'type': 'integer'}}}
+
+    def _make_ctx(self, fault_on_lists=False, fault_on_messages=False,
+                  fault_on_subscribed_contacts=False,
+                  fault_on_message_substreams=None, list_id=42, msg_id=77):
+        """
+        Build a mock context with configurable fault injection.
+        GetContactListCollection returns one list with ListID=list_id.
+        ReportListMessageActivity returns a response containing msg_id.
+        """
+        ctx = MagicMock()
         if fault_on_lists:
             ctx.client.service.GetContactListCollection.side_effect = Fault("Access denied")
+        else:
+            mock_list = MagicMock()
+            mock_list.ListID = list_id
+            ctx.client.service.GetContactListCollection.return_value = [mock_list]
+
+        if fault_on_messages:
+            ctx.client.service.ReportListMessageActivity.side_effect = Fault("Access denied")
+        else:
+            mock_msg = MagicMock()
+            mock_msg.__getitem__ = lambda s, k: msg_id if k == 'MsgID' else None
+            ctx.client.service.ReportListMessageActivity.return_value = {
+                'ReportListMessageActivityResult': {'WSMessageActivity': [mock_msg]}
+            }
+
+        if fault_on_subscribed_contacts:
+            ctx.client.service.ReportRangeSubscribedContacts.side_effect = Fault("Access denied")
+
+        for stream_id, endpoint in _MESSAGE_SUBSTREAM_ENDPOINTS.items():
+            if stream_id in (fault_on_message_substreams or []):
+                getattr(ctx.client.service, endpoint).side_effect = Fault("Access denied")
+
         return ctx
 
     @patch('tap_listrak.schemas.load_schema')
-    def test_discover_all_streams_when_lists_accessible(self, mock_load_schema):
-        mock_load_schema.return_value = {'type': 'object', 'properties': {'ListID': {'type': 'integer'}}}
+    def test_all_streams_included_when_all_accessible(self, mock_load_schema):
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
         ctx = self._make_ctx()
         catalog = discover(ctx)
-        stream_ids = {s.tap_stream_id for s in catalog.streams}
-        self.assertEqual(stream_ids, set(schemas.stream_ids))
+        self.assertEqual(
+            {s.tap_stream_id for s in catalog.streams}, set(schemas.stream_ids)
+        )
 
     @patch('tap_listrak.schemas.load_schema')
-    def test_discover_raises_when_lists_inaccessible(self, mock_load_schema):
-        mock_load_schema.return_value = {'type': 'object', 'properties': {'ListID': {'type': 'integer'}}}
-        ctx = self._make_ctx(fault_on_lists=True)
-        with self.assertRaises(ListrakForbiddenError):
-            discover(ctx)
-
-    @patch('tap_listrak.schemas.load_schema')
-    def test_discover_excludes_lists_and_all_children_when_forbidden(self, mock_load_schema):
-        """When lists is forbidden, catalog must be empty → ListrakForbiddenError raised."""
-        mock_load_schema.return_value = {'type': 'object', 'properties': {'ListID': {'type': 'integer'}}}
+    def test_raises_when_lists_inaccessible(self, mock_load_schema):
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
         ctx = self._make_ctx(fault_on_lists=True)
         with self.assertRaises(ListrakForbiddenError) as cm:
             discover(ctx)
         self.assertIn("403", str(cm.exception))
 
     @patch('tap_listrak.schemas.load_schema')
+    def test_messages_and_all_substreams_excluded_when_messages_forbidden(self, mock_load_schema):
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
+        ctx = self._make_ctx(fault_on_messages=True)
+        catalog = discover(ctx)
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        for excluded in ('messages', 'message_clicks', 'message_opens', 'message_reads',
+                         'message_sends', 'message_unsubs', 'message_bounces'):
+            self.assertNotIn(excluded, stream_ids)
+        self.assertIn('lists', stream_ids)
+        self.assertIn('subscribed_contacts', stream_ids)
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_subscribed_contacts_excluded_when_forbidden(self, mock_load_schema):
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
+        ctx = self._make_ctx(fault_on_subscribed_contacts=True)
+        catalog = discover(ctx)
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertNotIn('subscribed_contacts', stream_ids)
+        self.assertIn('lists', stream_ids)
+        self.assertIn('messages', stream_ids)
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_individual_message_substream_excluded_when_forbidden(self, mock_load_schema):
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
+        ctx = self._make_ctx(fault_on_message_substreams=['message_clicks'])
+        catalog = discover(ctx)
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertNotIn('message_clicks', stream_ids)
+        self.assertIn('message_opens', stream_ids)
+        self.assertIn('messages', stream_ids)
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_messages_probed_with_correct_list_id(self, mock_load_schema):
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
+        ctx = self._make_ctx(list_id=99)
+        discover(ctx)
+        self.assertEqual(
+            ctx.client.service.ReportListMessageActivity.call_args[1]['ListID'], 99
+        )
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_subscribed_contacts_probed_with_correct_list_id(self, mock_load_schema):
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
+        ctx = self._make_ctx(list_id=99)
+        discover(ctx)
+        self.assertEqual(
+            ctx.client.service.ReportRangeSubscribedContacts.call_args[1]['ListID'], 99
+        )
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_message_substreams_probed_with_correct_msg_id(self, mock_load_schema):
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
+        ctx = self._make_ctx(msg_id=55)
+        discover(ctx)
+        for stream_id, endpoint in _MESSAGE_SUBSTREAM_ENDPOINTS.items():
+            svc = getattr(ctx.client.service, endpoint)
+            self.assertEqual(
+                svc.call_args[1]['MsgID'], 55,
+                f"{stream_id} should be probed with MsgID=55"
+            )
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_message_substreams_skipped_when_no_msg_id(self, mock_load_schema):
+        """If messages returns no data, message_* probes are skipped and streams kept."""
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
+        ctx = MagicMock()
+        mock_list = MagicMock()
+        mock_list.ListID = 1
+        ctx.client.service.GetContactListCollection.return_value = [mock_list]
+        ctx.client.service.ReportListMessageActivity.return_value = {
+            'ReportListMessageActivityResult': None
+        }
+        catalog = discover(ctx)
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertEqual(stream_ids, set(schemas.stream_ids))
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_all_child_probes_skipped_when_no_lists(self, mock_load_schema):
+        """Empty GetContactListCollection → no child probes, all streams in catalog."""
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
+        ctx = MagicMock()
+        ctx.client.service.GetContactListCollection.return_value = []
+        catalog = discover(ctx)
+        ctx.client.service.ReportListMessageActivity.assert_not_called()
+        ctx.client.service.ReportRangeSubscribedContacts.assert_not_called()
+        self.assertEqual(
+            {s.tap_stream_id for s in catalog.streams}, set(schemas.stream_ids)
+        )
+
+    @patch('tap_listrak.schemas.load_schema')
+    def test_schema_loaded_only_for_accessible_streams(self, mock_load_schema):
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
+        ctx = self._make_ctx(fault_on_messages=True)
+        discover(ctx)
+        loaded = {c[0][0] for c in mock_load_schema.call_args_list}
+        for excluded in ('messages', 'message_clicks', 'message_opens', 'message_reads',
+                         'message_sends', 'message_unsubs', 'message_bounces'):
+            self.assertNotIn(excluded, loaded)
+
+
+    @patch('tap_listrak.schemas.load_schema')
     def test_discover_probes_lists_endpoint(self, mock_load_schema):
-        mock_load_schema.return_value = {'type': 'object', 'properties': {'ListID': {'type': 'integer'}}}
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
         ctx = self._make_ctx()
         discover(ctx)
         ctx.client.service.GetContactListCollection.assert_called_once()
 
     @patch('tap_listrak.schemas.load_schema')
-    def test_discover_does_not_skip_schema_load_for_accessible_streams(self, mock_load_schema):
-        """All accessible stream schemas must be loaded during discovery."""
-        mock_load_schema.return_value = {'type': 'object', 'properties': {'id': {'type': 'integer'}}}
-        ctx = self._make_ctx()
+    def test_discover_loads_schema_only_for_accessible_streams(self, mock_load_schema):
+        """Schema is loaded only for streams that remain in the catalog."""
+        mock_load_schema.return_value = self._SIMPLE_SCHEMA
+        ctx = self._make_ctx(fault_on_messages=True)
         discover(ctx)
-        self.assertEqual(mock_load_schema.call_count, len(schemas.stream_ids))
+        loaded_ids = {call[0][0] for call in mock_load_schema.call_args_list}
+        for excluded in ('messages', 'message_clicks', 'message_opens',
+                         'message_reads', 'message_sends', 'message_unsubs',
+                         'message_bounces'):
+            self.assertNotIn(excluded, loaded_ids)
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -349,10 +349,12 @@ class TestCheckCredentialsAuthorized(unittest.TestCase):
         result = check_credentials_are_authorized(ctx)
         self.assertEqual(result, 7)
 
-    def test_returns_none_when_lists_empty(self):
+    def test_raises_when_lists_empty(self):
         ctx = MagicMock()
         ctx.client.service.GetContactListCollection.return_value = []
-        self.assertIsNone(check_credentials_are_authorized(ctx))
+        with self.assertRaises(ListrakForbiddenError) as cm:
+            check_credentials_are_authorized(ctx)
+        self.assertIn("403", str(cm.exception))
 
     def test_raises_forbidden_on_fault(self):
         ctx = self._make_ctx(fault=Fault("Access denied"))
@@ -509,17 +511,14 @@ class TestDiscoverAccessChecks(unittest.TestCase):
         self.assertEqual(stream_ids, set(schemas.stream_ids))
 
     @patch('tap_listrak.schemas.load_schema')
-    def test_all_child_probes_skipped_when_no_lists(self, mock_load_schema):
-        """Empty GetContactListCollection → no child probes, all streams in catalog."""
+    def test_raises_when_no_lists_in_account(self, mock_load_schema):
+        """Empty GetContactListCollection raises ListrakForbiddenError."""
         mock_load_schema.return_value = self._SIMPLE_SCHEMA
         ctx = MagicMock()
         ctx.client.service.GetContactListCollection.return_value = []
-        catalog = discover(ctx)
-        ctx.client.service.ReportListMessageActivity.assert_not_called()
-        ctx.client.service.ReportRangeSubscribedContacts.assert_not_called()
-        self.assertEqual(
-            {s.tap_stream_id for s in catalog.streams}, set(schemas.stream_ids)
-        )
+        with self.assertRaises(ListrakForbiddenError) as cm:
+            discover(ctx)
+        self.assertIn("403", str(cm.exception))
 
     @patch('tap_listrak.schemas.load_schema')
     def test_schema_loaded_only_for_accessible_streams(self, mock_load_schema):

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -352,9 +352,8 @@ class TestCheckCredentialsAuthorized(unittest.TestCase):
     def test_raises_when_lists_empty(self):
         ctx = MagicMock()
         ctx.client.service.GetContactListCollection.return_value = []
-        with self.assertRaises(ListrakForbiddenError) as cm:
-            check_credentials_are_authorized(ctx)
-        self.assertIn("403", str(cm.exception))
+        result = check_credentials_are_authorized(ctx)
+        self.assertIsNone(result)
 
     def test_raises_forbidden_on_fault(self):
         ctx = self._make_ctx(fault=Fault("Access denied"))
@@ -511,24 +510,24 @@ class TestDiscoverAccessChecks(unittest.TestCase):
         self.assertEqual(stream_ids, set(schemas.stream_ids))
 
     @patch('tap_listrak.schemas.load_schema')
-    def test_raises_when_no_lists_in_account(self, mock_load_schema):
-        """Empty GetContactListCollection raises ListrakForbiddenError."""
+    def test_lists_only_when_no_lists_in_account(self, mock_load_schema):
+        """Empty GetContactListCollection keeps lists and excludes dependent streams."""
         mock_load_schema.return_value = self._SIMPLE_SCHEMA
         ctx = MagicMock()
         ctx.client.service.GetContactListCollection.return_value = []
-        with self.assertRaises(ListrakForbiddenError) as cm:
-            discover(ctx)
-        self.assertIn("403", str(cm.exception))
+        catalog = discover(ctx)
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
+        self.assertEqual(stream_ids, {'lists'})
 
     @patch('tap_listrak.schemas.load_schema')
     def test_schema_loaded_only_for_accessible_streams(self, mock_load_schema):
         mock_load_schema.return_value = self._SIMPLE_SCHEMA
         ctx = self._make_ctx(fault_on_messages=True)
-        discover(ctx)
-        loaded = {c[0][0] for c in mock_load_schema.call_args_list}
+        catalog = discover(ctx)
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
         for excluded in ('messages', 'message_clicks', 'message_opens', 'message_reads',
                          'message_sends', 'message_unsubs', 'message_bounces'):
-            self.assertNotIn(excluded, loaded)
+            self.assertNotIn(excluded, stream_ids)
 
 
     @patch('tap_listrak.schemas.load_schema')
@@ -540,13 +539,13 @@ class TestDiscoverAccessChecks(unittest.TestCase):
 
     @patch('tap_listrak.schemas.load_schema')
     def test_discover_loads_schema_only_for_accessible_streams(self, mock_load_schema):
-        """Schema is loaded only for streams that remain in the catalog."""
+        """Only accessible streams remain in the catalog after access checks."""
         mock_load_schema.return_value = self._SIMPLE_SCHEMA
         ctx = self._make_ctx(fault_on_messages=True)
-        discover(ctx)
-        loaded_ids = {call[0][0] for call in mock_load_schema.call_args_list}
+        catalog = discover(ctx)
+        stream_ids = {s.tap_stream_id for s in catalog.streams}
         for excluded in ('messages', 'message_clicks', 'message_opens',
                          'message_reads', 'message_sends', 'message_unsubs',
                          'message_bounces'):
-            self.assertNotIn(excluded, loaded_ids)
+            self.assertNotIn(excluded, stream_ids)
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -4,8 +4,6 @@ from zeep.exceptions import Fault
 from tap_listrak import schemas, discover
 from tap_listrak.__init__ import (
     check_credentials_are_authorized,
-    _probe_list_dependent,
-    _probe_message_substream,
     _MESSAGE_SUBSTREAM_ENDPOINTS,
 )
 from tap_listrak.http import ListrakForbiddenError
@@ -349,7 +347,7 @@ class TestCheckCredentialsAuthorized(unittest.TestCase):
         result = check_credentials_are_authorized(ctx)
         self.assertEqual(result, 7)
 
-    def test_raises_when_lists_empty(self):
+    def test_returns_none_when_lists_empty(self):
         ctx = MagicMock()
         ctx.client.service.GetContactListCollection.return_value = []
         result = check_credentials_are_authorized(ctx)


### PR DESCRIPTION
# Description of change
This PR adds discovery-time authorization probing for the Listrak SOAP API so the tap can fail fast (or prune) when credentials don’t have read access, and updates packaging metadata accordingly.

[SAC-30942](https://qlik-dev.atlassian.net/browse/SAC-30942)

# Manual QA steps
- [ ]  Discovery: Running
- [ ]  Sync: Running
- [x]  Unit test

# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
